### PR TITLE
Widget slug proper dynamic URLS

### DIFF
--- a/classes/LBRYPress.php
+++ b/classes/LBRYPress.php
@@ -119,7 +119,8 @@ class LBRYPress
         $this->define('LBRY_LBC_PUBLISH', 'lbry_lbc_publish'); // amount of lbc to use per publish
         $this->define('LBRY_WILL_PUBLISH', '_lbry_will_publish'); // The meta key for if to publish to LBRY Network or not
         $this->define('LBRY_POST_CHANNEL', '_lbry_channel'); // The meta key for which channel to publish
-        $this->define('LBRY_PERM_URL', '_lbry_perm_url'); // The meta key for the permanent url of the published lbry post
+        $this->define('LBRY_CLAIM_ID', '_lbry_claim_id'); // The Claim ID for the post as it was published on LBRY
+        $this->define('LBRY_CANONICAL_URL', '_lbry_canonical_url'); // The canonical url for the published lbry post
         $this->define('LBRY_SPEECH_ASSET_URL', 'speech_asset_url'); // The meta key for an asset's speech url
     }
 

--- a/classes/LBRY_Daemon.php
+++ b/classes/LBRY_Daemon.php
@@ -149,8 +149,12 @@ class LBRY_Daemon
      * @param  string $claim_id
      * @return string           Canonical URL, null if not found
      */
-    public function canonical_url($claim_id)
+    public function canonical_url($claim_id = null)
     {
+        if (!$claim_id) {
+            return null;
+        }
+
         try {
             $result = $this->request(
                 'claim_search',
@@ -159,8 +163,6 @@ class LBRY_Daemon
                     'no_totals' => true
                 )
             );
-
-            error_log(print_r($result, true));
 
             $items = $result->result->items;
             if (!$items) {

--- a/classes/LBRY_Daemon.php
+++ b/classes/LBRY_Daemon.php
@@ -145,6 +145,36 @@ class LBRY_Daemon
     }
 
     /**
+     * Returns the canonical URL for the supplied claim ID, null otherwise
+     * @param  string $claim_id
+     * @return string           Canonical URL, null if not found
+     */
+    public function canonical_url($claim_id)
+    {
+        try {
+            $result = $this->request(
+                'claim_search',
+                array(
+                    'claim_id'  => $claim_id,
+                    'no_totals' => true
+                )
+            );
+
+            error_log(print_r($result, true));
+
+            $items = $result->result->items;
+            if (!$items) {
+                return null;
+            }
+
+            return $items[0]->canonical_url;
+        } catch (LBRYDaemonException $e) {
+            $this->logger->log('canonical_url error', $e->getMessage() . ' | Code: ' . $e->getCode());
+            return;
+        }
+    }
+
+    /**
      * Publishes a post to the LBRY Network
      * https://lbry.tech/api/sdk#publish
      * @param  array  $args        An array containing necessary data for publish post

--- a/classes/LBRY_Network_Publisher.php
+++ b/classes/LBRY_Network_Publisher.php
@@ -77,7 +77,14 @@ class LBRY_Network_Publisher
             $outputs = $result->outputs;
 
             if ($outputs && is_array($outputs)) {
-                update_post_meta($post->ID, LBRY_PERM_URL, $result->outputs[0]->permanent_url);
+                $output = $result->outputs[0];
+                $claim_id = $output->claim_id;
+                // Set Claim ID
+                update_post_meta($post->ID, LBRY_CLAIM_ID, $claim_id);
+
+                // Set Canonical URL
+                $canonical_url = LBRY()->daemon->canonical_url($claim_id);
+                update_post_meta($post->ID, LBRY_CANONICAL_URL, $canonical_url);
             }
         } catch (Exception $e) {
             error_log('Issue publishing post ' . $post->ID . ' to LBRY: ' .  $e->getMessage());

--- a/templates/published_on_lbry_banner.php
+++ b/templates/published_on_lbry_banner.php
@@ -1,15 +1,24 @@
 <?php
-    $url = get_post_meta(get_the_id(), LBRY_PRETTY_URL, true);
-
-    // Backwards compatible if LBRY_PRETTY_URL wasn't set
+    $url = get_post_meta(get_the_id(), LBRY_CANONICAL_URL, true);
     if (!$url) {
-        $url = get_post_meta(get_the_id(), LBRY_PERM_URL, true);
+        // Get channel canonical for backwards compatibility
+        $channel_id = get_post_meta(get_the_id(), LBRY_POST_CHANNEL, true);
+        $url = LBRY()->daemon->canonical_url($channel_id);
+    }
+
+    if ($url) {
+        $url = str_replace('lbry://', 'lbry.tv/', $url);
     }
 ?>
 <div class="lbry-published-banner">
     <h5>Stored Safely on Blockchain</h5>
     <p>
-        This post is published to <a href="https://lbry.io/get">LBRY</a> blockchain at <a href="<?= $url ?>"><?= $url ?></a>.
+        This post is published to <a href="https://lbry.io/get">LBRY</a> blockchain
+        <?php if($url): ?>
+            at <a href="https://<?= $url ?>"><?= $url ?></a>.
+        <?php else: ?>
+            .
+        <?php endif; ?>
     </p>
     <p>
         <a href="https://lbry.io/get" target="_blank">Try LBRY</a> to experience content freedom, earn crypto, and support The Anti-Media!

--- a/templates/published_on_lbry_banner.php
+++ b/templates/published_on_lbry_banner.php
@@ -1,13 +1,15 @@
 <?php
-// HACK: Fix this so its not TAM specific
-    global $post;
-    $slug = $post->post_name;
-    $url = '@AntiMedia/' . $slug;
+    $url = get_post_meta(get_the_id(), LBRY_PRETTY_URL, true);
+
+    // Backwards compatible if LBRY_PRETTY_URL wasn't set
+    if (!$url) {
+        $url = get_post_meta(get_the_id(), LBRY_PERM_URL, true);
+    }
 ?>
 <div class="lbry-published-banner">
     <h5>Stored Safely on Blockchain</h5>
     <p>
-        This post is published to <a href="https://lbry.io/get">LBRY</a> blockchain at <a href="https://open.lbry.io/<?= $url ?>">lbry://<?= $url ?></a>.
+        This post is published to <a href="https://lbry.io/get">LBRY</a> blockchain at <a href="<?= $url ?>"><?= $url ?></a>.
     </p>
     <p>
         <a href="https://lbry.io/get" target="_blank">Try LBRY</a> to experience content freedom, earn crypto, and support The Anti-Media!


### PR DESCRIPTION
For the front-end post widget, the LBRY Channel was previously hardcoded as a hotfix. 

In this PR: 

- Saving claimID as post meta when post is published to LBRY
- canonical_url function in LBRY_Daemon to get canonical of any claim ID
- Dynamic Widget link, with backwards compatibility if Claim ID has not been saved against post

Fixes #15 